### PR TITLE
Update default response settings

### DIFF
--- a/microbellm/templates/dashboard.html
+++ b/microbellm/templates/dashboard.html
@@ -32,12 +32,12 @@
         </div>
         <div class="setting-item">
             <label for="rateLimitInput">Requests per second:</label>
-            <input type="number" id="rateLimitInput" min="0.1" max="100" step="0.1" value="1">
+            <input type="number" id="rateLimitInput" min="0.1" max="100" step="0.1" value="30">
             <button onclick="updateRateLimit()" class="btn btn-sm btn-primary">Update</button>
         </div>
         <div class="setting-item">
             <label for="concurrentInput">Concurrent requests:</label>
-            <input type="number" id="concurrentInput" min="1" max="20" step="1" value="4">
+            <input type="number" id="concurrentInput" min="1" max="30" step="1" value="30">
             <button onclick="updateConcurrency()" class="btn btn-sm btn-primary">Update</button>
             <small class="form-help">Number of species to process in parallel</small>
         </div>

--- a/microbellm/templates/settings.html
+++ b/microbellm/templates/settings.html
@@ -45,7 +45,7 @@
     <h2>Processing Configuration</h2>
     <div class="setting-item">
         <label for="rateLimitInput">Requests per second:</label>
-        <input type="number" id="rateLimitInput" min="0.1" max="10" step="0.1" value="2.0">
+        <input type="number" id="rateLimitInput" min="0.1" max="100" step="0.1" value="30.0">
         <button onclick="updateRateLimit()" class="btn btn-primary btn-small">Update</button>
     </div>
     <div class="setting-info">

--- a/microbellm/web_app.py
+++ b/microbellm/web_app.py
@@ -48,9 +48,9 @@ class ProcessingManager:
         self.job_queue = []
         self.paused_combinations = set()
         self.stopped_combinations = set()
-        self.requests_per_second = 1.0  # Default rate limit
+        self.requests_per_second = 30.0  # Default rate limit
         self.last_request_time = {}
-        self.max_concurrent_requests = 4  # Default concurrent requests
+        self.max_concurrent_requests = 30  # Default concurrent requests
         self.executor = None  # Thread pool executor
         self.init_database()
     
@@ -1328,7 +1328,7 @@ class ProcessingManager:
 
     def set_rate_limit(self, requests_per_second):
         """Set the rate limit for API requests"""
-        self.requests_per_second = max(0.1, min(10.0, requests_per_second))  # Clamp between 0.1 and 10 RPS
+        self.requests_per_second = max(0.1, min(100.0, requests_per_second))  # Clamp between 0.1 and 100 RPS
         print(f"Rate limit set to {self.requests_per_second} requests per second")
     
     def get_already_processed_species(self, species_file, model, system_template, user_template):
@@ -1635,7 +1635,7 @@ def stop_combination_api(combination_id):
 @app.route('/api/set_rate_limit', methods=['POST'])
 def set_rate_limit_api():
     data = request.get_json()
-    requests_per_second = data.get('requests_per_second', 1.0)
+    requests_per_second = data.get('requests_per_second', 30.0)
     max_concurrent_requests = data.get('max_concurrent_requests')
     
     processing_manager.set_rate_limit(requests_per_second)


### PR DESCRIPTION
Update default values for requests per second and concurrent requests to 30, and fix a bug that prevented setting requests per second above 10.

The `set_rate_limit` function had a hardcoded clamp that limited the requests per second to a maximum of 10. This caused user-set values above 10 to be silently reduced and then reset to the old hardcoded defaults (1) upon reinitialization. This PR increases the clamp limit to 100 and updates all default values to 30.